### PR TITLE
fix: Prevent shimming objects as a function even when objects start with on

### DIFF
--- a/trace-anything.js
+++ b/trace-anything.js
@@ -126,7 +126,8 @@ class TraceAnything {
 
     if (options.events) {
       // Shim any "on" event listener properties.
-      for (const k of allProperties.filter((k) => k.startsWith('on'))) {
+      for (const k of allProperties.filter(
+        (k) => (k.startsWith('on')) && object.hasOwnProperty(k))) {
         TraceAnything._shimEventListenerProperty(
             traced, object, k, className, options);
       }


### PR DESCRIPTION
The blink wpt tests are failing when EME logger is enabled due to shimming anything starting with on as a function.
This is fixed by using the js property of object.hasOwnProperty, which only looks at the properties of the object, not the ones that are inherited. 