### PR TITLE
fix(ci): Update release for trusted publishing

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,13 +1,16 @@
+name: Release
+
 on:
   push:
     branches:
       - main
 
-name: release-please
-
 jobs:
-  release-please:
+  release:
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs.release_created }}
 
     permissions:
       # Write to "contents" is needed to create a release
@@ -22,34 +25,46 @@ jobs:
         with:
           release-type: node
 
-      # The logic below handles npm publication.  Each step is conditional on a
-      # release having been created by someone merging the release PR.
+  npm:
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.release_created
+
+    permissions:
+      # Required for OIDC ("trusted publishing")
+      id-token: write
+      # Write to "contents" is needed to attach files to the release
+      contents: write
+
+    steps:
       - uses: actions/checkout@v4
         with:
-          ref: refs/tags/${{ steps.release.outputs.tag_name }}
+          ref: refs/tags/${{ needs.release.outputs.tag_name }}
           persist-credentials: false
-        if: ${{ steps.release.outputs.release_created }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # NOTE: OIDC fails with node less than 24.
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.release_created }}
+
+      # NOTE: OIDC fails with npm less than 11.5.1.
+      - name: Update npm
+        run: sudo npm install -g npm@11.7
 
       - run: npm ci
-        if: ${{ steps.release.outputs.release_created }}
 
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}
+      # NOTE: OIDC fails if the repository URL doesn't match package.json.
+      - run: npm pkg set repository.url=https://github.com/${{ github.repository }}
 
-      - run: npm pack
-        if: ${{ steps.release.outputs.release_created }}
+      # NOTE: --access public is required for scoped forks.
+      - run: npm publish --access public
+
+      # Stores the file name into the file "tarball" (unpredictable for forks).
+      - run: npm pack > tarball
 
       - name: Attach files to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload --clobber "${{ steps.release.outputs.tag_name }}" trace-anything-*.tgz
-        if: ${{ steps.release.outputs.release_created }}
+        # Reads the file name from the file "tarball".
+        run: gh release upload --clobber "${{ needs.release.outputs.tag_name }}" "$(cat tarball)"


### PR DESCRIPTION
Also splits up the workflow to be more robust and allow reruns of the npm steps on temporary failure.

See shaka-project/shaka-player#9132
See shaka-project/shaka-github-tools#56